### PR TITLE
Made date field readonly

### DIFF
--- a/app/components/post-contribution-form/template.hbs
+++ b/app/components/post-contribution-form/template.hbs
@@ -12,7 +12,7 @@
       placeholder="Beschreibe hier deinen Open Source Beitrag..."
       required=true
       }}
-    {{f.date-field "date" label="Datum" placeholder="2016-12-31" required=true}}
+    {{f.date-field "date" label="Datum" placeholder="2016-12-31" required=true readonly=true}}
     <div class="text-center">
       {{f.button "Cancel" class="btn-link m-r-1" click=(action 'cancel')}}
       {{f.submit disabled=(or changeset.isInvalid changeset.isPristine)}}


### PR DESCRIPTION
Made the date field in the post contribution form readonly. Otherwise it
is possible to mess with the date and easily get NaN-NaN-NaN sort of
stuff