### PR TITLE
Reihenfolge der Buttons und deren Label ändern

### DIFF
--- a/app/components/post-contribution-form/template.hbs
+++ b/app/components/post-contribution-form/template.hbs
@@ -19,9 +19,9 @@
       }}
 
     <div class="button-row">
-      {{f.button "Cancel" class="btn-link" click=(action "cancel")}}
-      {{f.submit
+      {{f.submit "Erfassen"
         disabled=(or changeset.isInvalid changeset.isPristine changeset.isSaving)}}
+      {{f.button "Abbrechen" class="btn-link" click=(action "cancel")}}
     </div>
   {{/form-for}}
 

--- a/tests/integration/components/post-contribution-form/component-test.js
+++ b/tests/integration/components/post-contribution-form/component-test.js
@@ -48,7 +48,7 @@ describe('Integration | Component | post contribution form', function() {
       {{post-contribution-form contribution=model oncancel=(action cancel)}}
     `)
 
-    this.$('button[label="Cancel"]').click()
+    this.$('button[label="Abbrechen"]').click()
 
     expect(cancelled).to.be.true
   })


### PR DESCRIPTION
Wenn links aligned, soll zuerst primary action (submit) und erst dann secondary action (cancel) kommen.