### PR TITLE
Visually highlight support for OSM-Contributions

### DIFF
--- a/app/components/contribution-bubbles/template.hbs
+++ b/app/components/contribution-bubbles/template.hbs
@@ -32,3 +32,11 @@
     </div>
   </div>
 </div>
+<div class="layout-row flex-center">
+  <div class="bubble-wrapper">
+    <div class="bubble">
+      {{fa-icon 'globe'}}
+      <small>OSM</small>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Since the text on the index-page mentions OSM, 
I hereby propose adding a bubble for this kind of 
contribution.

I hope to add a bubble also below the others in order
to achieve a combination of a bunch of grapes (like a 
bunch of fruity contributions) and maybe christmas-tree
decoration.

With high hopes of making the world a better, more inclusive and of course prettier place, I request to have these changes integrated into the codebase.